### PR TITLE
Add order scheduling without portion sizes

### DIFF
--- a/app/cart/page.tsx
+++ b/app/cart/page.tsx
@@ -17,6 +17,8 @@ export default function CartPage() {
     };
 
     const handlePaymentSuccess = () => {
+        const existing = JSON.parse(localStorage.getItem('activeOrders') || '[]');
+        localStorage.setItem('activeOrders', JSON.stringify([...existing, ...items]));
         clearCart();
         router.push('/success');
         setShowCardDetails(false);
@@ -57,13 +59,13 @@ export default function CartPage() {
                 <div className="lg:col-span-2">
                     <div className="bg-white rounded-lg shadow-md p-6">
                         {items.map((item) => (
-                            <div key={`${item.meal.id}-${item.portionSize}`} className="border-b last:border-b-0 py-4">
+                            <div key={`${item.meal.id}-${item.orderTime}`} className="border-b last:border-b-0 py-4">
                                 <div className="flex justify-between items-start">
                                     <div>
                                         <h3 className="text-lg font-semibold">{item.meal.name}</h3>
-                                        <p className="text-gray-600 capitalize">{item.portionSize} Portion</p>
+                                        <p className="text-gray-600">{new Date(item.orderTime).toLocaleString()}</p>
                                         <p className="text-gray-600">
-                                            {item.meal.portion_sizes[item.portionSize].price.toFixed(2)} € each
+                                            {item.meal.portion_sizes.medium.price.toFixed(2)} € each
                                         </p>
                                     </div>
                                     <div className="flex items-center gap-4">
@@ -71,7 +73,7 @@ export default function CartPage() {
                                             <Button
                                                 variant="outline"
                                                 size="icon"
-                                                onClick={() => updateQuantity(item.meal.id, item.portionSize, item.quantity - 1)}
+                                                onClick={() => updateQuantity(item.meal.id, item.orderTime, item.quantity - 1)}
                                             >
                                                 <Minus className="w-4 h-4" />
                                             </Button>
@@ -79,7 +81,7 @@ export default function CartPage() {
                                             <Button
                                                 variant="outline"
                                                 size="icon"
-                                                onClick={() => updateQuantity(item.meal.id, item.portionSize, item.quantity + 1)}
+                                                onClick={() => updateQuantity(item.meal.id, item.orderTime, item.quantity + 1)}
                                             >
                                                 <Plus className="w-4 h-4" />
                                             </Button>
@@ -87,7 +89,7 @@ export default function CartPage() {
                                         <Button
                                             variant="ghost"
                                             size="icon"
-                                            onClick={() => removeFromCart(item.meal.id, item.portionSize)}
+                                            onClick={() => removeFromCart(item.meal.id, item.orderTime)}
                                         >
                                             <Trash2 className="w-4 h-4 text-red-500" />
                                         </Button>

--- a/app/orders/page.tsx
+++ b/app/orders/page.tsx
@@ -1,0 +1,51 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { Button } from '@/components/ui/button';
+import Link from 'next/link';
+import { Meal } from '@/types/meal';
+
+interface OrderItem {
+    meal: Meal;
+    orderTime: string;
+    quantity: number;
+}
+
+export default function OrdersPage() {
+    const [orders, setOrders] = useState<OrderItem[]>([]);
+
+    useEffect(() => {
+        const data = JSON.parse(localStorage.getItem('activeOrders') || '[]');
+        setOrders(data);
+    }, []);
+
+    if (orders.length === 0) {
+        return (
+            <div className="container mx-auto py-10">
+                <h1 className="text-3xl font-bold mb-8">Aktive Bestellungen</h1>
+                <p className="text-gray-600">Keine Bestellungen vermerkt.</p>
+            </div>
+        );
+    }
+
+    return (
+        <div className="container mx-auto py-10">
+            <h1 className="text-3xl font-bold mb-8">Aktive Bestellungen</h1>
+            <div className="space-y-4">
+                {orders.map((item, idx) => (
+                    <div key={idx} className="border rounded p-4">
+                        <h2 className="font-semibold">{item.meal.name}</h2>
+                        <p>{new Date(item.orderTime).toLocaleString()}</p>
+                        <p>Menge: {item.quantity}</p>
+                        <p>Preis: {item.meal.portion_sizes.medium.price.toFixed(2)} €</p>
+                    </div>
+                ))}
+            </div>
+            <div className="mt-6">
+                <Link href="/menu">
+                    <Button>Weitere Gerichte</Button>
+                </Link>
+            </div>
+        </div>
+    );
+}

--- a/components/header-auth.tsx
+++ b/components/header-auth.tsx
@@ -50,6 +50,9 @@ export default function HeaderAuth() {
               )}
             </Button>
           </Link>
+          <Link href="/orders">
+            <Button variant="ghost">Vermerkt</Button>
+          </Link>
           <Button variant="ghost" onClick={handleSignOut}>
             Sign Out
           </Button>

--- a/components/meal-card.tsx
+++ b/components/meal-card.tsx
@@ -19,7 +19,7 @@ interface MealCardProps {
 
 export function MealCard({ meal, className = '' }: MealCardProps) {
     const { addToCart } = useCart();
-    const [selectedSize, setSelectedSize] = useState<string | null>(null);
+    const [orderTime, setOrderTime] = useState<string>('');
 
     return (
         <div className={`border rounded-lg p-4 hover:shadow-md transition-shadow ${className}`}>
@@ -37,28 +37,24 @@ export function MealCard({ meal, className = '' }: MealCardProps) {
             <p className="text-gray-600 mb-3">{meal.description}</p>
             
             <div className="space-y-4">
-                {/* Portion Sizes */}
                 <div>
-                    <h4 className="font-medium mb-2">Portion Sizes</h4>
-                    <div className="grid grid-cols-3 gap-2">
-                        {Object.entries(meal.portion_sizes).map(([size, { price, description }]) => (
-                            <div
-                                key={size}
-                                className={`border rounded p-2 text-center cursor-pointer transition-colors ${
-                                    selectedSize === size ? 'border-blue-500 bg-blue-50' : ''
-                                }`}
-                                onClick={() => setSelectedSize(size)}
-                            >
-                                <div className="text-sm font-medium capitalize">{size}</div>
-                                <div className="text-lg font-semibold">{price.toFixed(2)} €</div>
-                                <div className="text-xs text-gray-500">{description}</div>
-                            </div>
-                        ))}
+                    <div className="flex items-center justify-between mb-2">
+                        <span className="font-medium">Price</span>
+                        <span className="font-semibold">{meal.portion_sizes.medium.price.toFixed(2)} €</span>
                     </div>
-                    {selectedSize && (
+                    <input
+                        type="datetime-local"
+                        className="border rounded w-full px-2 py-1 mb-2"
+                        value={orderTime}
+                        onChange={(e) => setOrderTime(e.target.value)}
+                    />
+                    {orderTime && (
                         <Button
-                            className="w-full mt-2"
-                            onClick={() => addToCart(meal, selectedSize)}
+                            className="w-full"
+                            onClick={() => {
+                                addToCart(meal, orderTime);
+                                setOrderTime('');
+                            }}
                         >
                             <ShoppingCart className="w-4 h-4 mr-2" />
                             Add to Cart

--- a/lib/cart-context.tsx
+++ b/lib/cart-context.tsx
@@ -5,15 +5,15 @@ import { Meal } from '@/types/meal';
 
 interface CartItem {
     meal: Meal;
-    portionSize: string;
+    orderTime: string;
     quantity: number;
 }
 
 interface CartContextType {
     items: CartItem[];
-    addToCart: (meal: Meal, portionSize: string) => void;
-    removeFromCart: (mealId: string, portionSize: string) => void;
-    updateQuantity: (mealId: string, portionSize: string, quantity: number) => void;
+    addToCart: (meal: Meal, orderTime: string) => void;
+    removeFromCart: (mealId: string, orderTime: string) => void;
+    updateQuantity: (mealId: string, orderTime: string, quantity: number) => void;
     clearCart: () => void;
     totalItems: number;
     totalPrice: number;
@@ -24,41 +24,41 @@ const CartContext = createContext<CartContextType | undefined>(undefined);
 export function CartProvider({ children }: { children: ReactNode }) {
     const [items, setItems] = useState<CartItem[]>([]);
 
-    const addToCart = (meal: Meal, portionSize: string) => {
+    const addToCart = (meal: Meal, orderTime: string) => {
         setItems(currentItems => {
             const existingItem = currentItems.find(
-                item => item.meal.id === meal.id && item.portionSize === portionSize
+                item => item.meal.id === meal.id && item.orderTime === orderTime
             );
 
             if (existingItem) {
                 return currentItems.map(item =>
-                    item.meal.id === meal.id && item.portionSize === portionSize
+                    item.meal.id === meal.id && item.orderTime === orderTime
                         ? { ...item, quantity: item.quantity + 1 }
                         : item
                 );
             }
 
-            return [...currentItems, { meal, portionSize, quantity: 1 }];
+            return [...currentItems, { meal, orderTime, quantity: 1 }];
         });
     };
 
-    const removeFromCart = (mealId: string, portionSize: string) => {
+    const removeFromCart = (mealId: string, orderTime: string) => {
         setItems(currentItems =>
             currentItems.filter(
-                item => !(item.meal.id === mealId && item.portionSize === portionSize)
+                item => !(item.meal.id === mealId && item.orderTime === orderTime)
             )
         );
     };
 
-    const updateQuantity = (mealId: string, portionSize: string, quantity: number) => {
+    const updateQuantity = (mealId: string, orderTime: string, quantity: number) => {
         if (quantity < 1) {
-            removeFromCart(mealId, portionSize);
+            removeFromCart(mealId, orderTime);
             return;
         }
 
         setItems(currentItems =>
             currentItems.map(item =>
-                item.meal.id === mealId && item.portionSize === portionSize
+                item.meal.id === mealId && item.orderTime === orderTime
                     ? { ...item, quantity }
                     : item
             )
@@ -71,7 +71,7 @@ export function CartProvider({ children }: { children: ReactNode }) {
 
     const totalItems = items.reduce((sum, item) => sum + item.quantity, 0);
     const totalPrice = items.reduce((sum, item) => {
-        const price = item.meal.portion_sizes[item.portionSize].price;
+        const price = item.meal.portion_sizes.medium.price;
         return sum + price * item.quantity;
     }, 0);
 


### PR DESCRIPTION
## Summary
- remove portion selection from meal card and show single price
- allow selecting a datetime when adding to cart
- track cart items with order time
- store completed orders in `localStorage` and list them on new **Vermerkt** page
- link orders page from header

## Testing
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ab087b92083229b89174d43ab430c