### PR TITLE
Implement account type discounts

### DIFF
--- a/app/auth/page.tsx
+++ b/app/auth/page.tsx
@@ -36,6 +36,7 @@ const formSchema = z.object({
   email: z.string().email("Please enter a valid email address"),
   password: z.string().min(6, "Password must be at least 6 characters"),
   role: z.enum(["user", "admin"]).optional(),
+  accountType: z.enum(["Student", "Teacher", "External"]),
 });
 
 export default function AuthPage() {
@@ -49,6 +50,7 @@ export default function AuthPage() {
       email: "",
       password: "",
       role: "user",
+      accountType: "Student",
     },
   });
 
@@ -69,6 +71,9 @@ export default function AuthPage() {
     formData.append("password", data.password);
     if (isSignUp && data.role) {
       formData.append("role", data.role);
+    }
+    if (isSignUp && data.accountType) {
+      formData.append("accountType", data.accountType);
     }
     
     try {
@@ -138,7 +143,7 @@ export default function AuthPage() {
                   name="role"
                   render={({ field }) => (
                     <FormItem>
-                      <FormLabel>Account Type</FormLabel>
+                      <FormLabel>Role</FormLabel>
                       <Select
                         onValueChange={field.onChange}
                         defaultValue={field.value}
@@ -151,6 +156,33 @@ export default function AuthPage() {
                         <SelectContent>
                           <SelectItem value="user">Normal User</SelectItem>
                           <SelectItem value="admin">Admin</SelectItem>
+                        </SelectContent>
+                      </Select>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              )}
+              {isSignUp && (
+                <FormField
+                  control={form.control}
+                  name="accountType"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Account Type</FormLabel>
+                      <Select
+                        onValueChange={field.onChange}
+                        defaultValue={field.value}
+                      >
+                        <FormControl>
+                          <SelectTrigger>
+                            <SelectValue placeholder="Select account type" />
+                          </SelectTrigger>
+                        </FormControl>
+                        <SelectContent>
+                          <SelectItem value="Student">Schüler</SelectItem>
+                          <SelectItem value="Teacher">Lehrer</SelectItem>
+                          <SelectItem value="External">Extern</SelectItem>
                         </SelectContent>
                       </Select>
                       <FormMessage />

--- a/app/cart/page.tsx
+++ b/app/cart/page.tsx
@@ -6,10 +6,14 @@ import { Button } from '@/components/ui/button';
 import { Minus, Plus, Trash2 } from 'lucide-react';
 import { useRouter } from 'next/navigation';
 import CardDetailsInput from '@/components/CardDetailsInput';
+import { useAccountType } from '@/lib/use-account-type';
+import { calculateDiscount } from '@/utils/discount';
+import { DiscountDisplay } from '@/components/discount-display';
 
 export default function CartPage() {
     const { items, removeFromCart, updateQuantity, totalPrice, clearCart } = useCart();
     const router = useRouter();
+    const accountType = useAccountType();
     const [showCardDetails, setShowCardDetails] = useState(false);
 
     const handleCheckout = () => {
@@ -27,6 +31,8 @@ export default function CartPage() {
     const handleCancelPayment = () => {
         setShowCardDetails(false);
     };
+
+    const discountCalc = calculateDiscount(totalPrice, accountType);
 
     if (items.length === 0) {
         return (
@@ -103,16 +109,7 @@ export default function CartPage() {
                 <div className="lg:col-span-1">
                     <div className="bg-white rounded-lg shadow-md p-6">
                         <h2 className="text-xl font-semibold mb-4">Order Summary</h2>
-                        <div className="space-y-2 mb-4">
-                            <div className="flex justify-between">
-                                <span>Subtotal</span>
-                                <span>{totalPrice.toFixed(2)} €</span>
-                            </div>
-                            <div className="flex justify-between font-semibold text-lg">
-                                <span>Total</span>
-                                <span>{totalPrice.toFixed(2)} €</span>
-                            </div>
-                        </div>
+                        <DiscountDisplay calculation={discountCalc} className="mb-4" />
                         <Button
                             className="w-full"
                             onClick={handleCheckout}

--- a/lib/use-account-type.tsx
+++ b/lib/use-account-type.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { createClient } from '@/utils/supabase/client';
+import { AccountType } from '@/types/user';
+
+export function useAccountType(initial: AccountType = 'External'): AccountType {
+    const [accountType, setAccountType] = useState<AccountType>(initial);
+    const supabase = createClient();
+
+    useEffect(() => {
+        const fetchType = async () => {
+            const { data: { user } } = await supabase.auth.getUser();
+            const type = user?.user_metadata?.account_type as AccountType | undefined;
+            if (type) setAccountType(type);
+        };
+
+        fetchType();
+
+        const { data: { subscription } } = supabase.auth.onAuthStateChange((_, session) => {
+            const type = session?.user?.user_metadata?.account_type as AccountType | undefined;
+            if (type) setAccountType(type);
+        });
+
+        return () => {
+            subscription?.unsubscribe();
+        };
+    }, [supabase]);
+
+    return accountType;
+}


### PR DESCRIPTION
## Summary
- capture the user's account type and provide a React hook for it
- extend the signup page to choose Student/Teacher/External account types
- store the chosen account type on signup and create a profile row
- use the account type to apply discounts in the cart

## Testing
- `npm install`
- `npm run build` *(fails: Failed to fetch font `Geist`)*

------
https://chatgpt.com/codex/tasks/task_e_684fc22e109083229b1a3ebf3a3f3a87